### PR TITLE
feat: Redux 초기 세팅 적용

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,13 +4,14 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
-import { defineConfig, globalIgnores } from "eslint/config";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-export default defineConfig([
+export default tseslint.config(
     // 전역 무시 설정
-    globalIgnores(["dist", "build", "node_modules", ".cache"]),
+    {
+        ignores: ["dist", "build", "node_modules", ".cache"],
+    },
 
     // 메인 설정 (TypeScript, React)
     {
@@ -18,11 +19,7 @@ export default defineConfig([
         extends: [
             js.configs.recommended, // ESLint 기본 추천 규칙
             ...tseslint.configs.recommendedTypeChecked, // TypeScript 추천 규칙
-            ,
             react.configs.flat.recommended, // React 핵심 추천 규칙
-            jsxA11y.configs.recommended, // 웹 접근성 규칙
-            reactHooks.configs["recommended-latest"], // React 훅 규칙
-            reactRefresh.configs.vite, // Vite + React-Refresh 규칙
             prettierConfig, // Prettier와 충돌하는 스타일 규칙 모두 비활성화
         ],
         // 플러그인 등록
@@ -31,7 +28,6 @@ export default defineConfig([
             "react-hooks": reactHooks,
             "react-refresh": reactRefresh,
             "jsx-a11y": jsxA11y,
-            "@typescript-eslint": tseslint.plugin,
         },
         languageOptions: {
             ecmaVersion: "latest", // 항상 최신 EcmaScript 버전 사용
@@ -39,7 +35,7 @@ export default defineConfig([
             globals: globals.browser, // 브라우저 환경
             parser: tseslint.parser, // TypeScript 파서 지정
             parserOptions: {
-                project: true, // 타입 인식 규칙 활성화 (tsconfig.json 경로 필요)
+                projectService: true, // 타입 인식 규칙 활성화 (tsconfig.json 경로 필요)
                 tsconfigRootDir: import.meta.dirname, // config 파일 기준 tsconfig.json 검색, 최상단 검색
             },
         },
@@ -54,7 +50,7 @@ export default defineConfig([
             "react/react-in-jsx-scope": "off", // 최신 React는 import React 불필요
             "react/prop-types": "off", // TypeScript를 사용하므로 prop-types 불필요
 
-            // --- React 훅스 규칙 ---
+            // --- React hooks 규칙 ---
             "react-hooks/rules-of-hooks": "error", // 훅스 규칙 위반 시 오류
             "react-hooks/exhaustive-deps": "warn", // 의존성 배열 경고
 
@@ -64,7 +60,12 @@ export default defineConfig([
                 { argsIgnorePattern: "^_" },
             ], // 사용 안 한 변수 경고 (단, _로 시작하면 무시)
 
-            // --- React-Refresh 규칙 ---
+            // JSX A11y 핵심 규칙
+            "jsx-a11y/alt-text": "warn",
+            "jsx-a11y/aria-props": "warn",
+            "jsx-a11y/aria-role": "warn",
+
+            // React Refresh 규칙
             "react-refresh/only-export-components": "warn", // Vite HMR을 위한 규칙
 
             // --- 기타 ---
@@ -81,5 +82,5 @@ export default defineConfig([
             sourceType: "module",
             globals: globals.node, // Node.js 환경
         },
-    },
-]);
+    }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
             "version": "0.0.0",
             "dependencies": {
                 "@hookform/resolvers": "^5.2.2",
+                "@reduxjs/toolkit": "^2.10.1",
                 "@tailwindcss/vite": "^4.1.16",
                 "react": "^19.1.1",
                 "react-dom": "^19.1.1",
                 "react-hook-form": "^7.66.0",
+                "react-redux": "^9.2.0",
                 "react-router-dom": "^7.9.4",
                 "tailwindcss": "^4.1.16",
                 "zod": "^4.1.12"
@@ -758,6 +760,32 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.10.1.tgz",
+            "integrity": "sha512-/U17EXQ9Do9Yx4DlNGU6eVNfZvFJfYpUtRRdLf19PbPjdWBxNlxGZXywQZ1p1Nz8nMkWplTI7iD/23m07nolDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^10.2.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.43",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.43.tgz",
@@ -1050,6 +1078,12 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+            "license": "MIT"
         },
         "node_modules/@standard-schema/utils": {
             "version": "0.3.0",
@@ -1567,7 +1601,7 @@
             "version": "19.2.2",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
             "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.0.2"
@@ -1582,6 +1616,12 @@
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.46.2",
@@ -2364,7 +2404,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/damerau-levenshtein": {
@@ -3526,6 +3566,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/immer": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
             }
         },
         "node_modules/import-fresh": {
@@ -4997,6 +5047,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-router": {
             "version": "7.9.4",
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
@@ -5033,6 +5106,21 @@
             "peerDependencies": {
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -5078,6 +5166,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "2.0.0-next.5",
@@ -5949,6 +6043,15 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     },
     "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@reduxjs/toolkit": "^2.10.1",
         "@tailwindcss/vite": "^4.1.16",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.66.0",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^7.9.4",
         "tailwindcss": "^4.1.16",
         "zod": "^4.1.12"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
 import { Outlet } from "react-router-dom";
+import Modal from "./components/common/modal";
 
 function App() {
     return (
-        <main className="layout">
-            <Outlet />
-        </main>
+        <>
+            <main className="layout">
+                <Outlet />
+            </main>
+            <Modal />
+        </>
     );
 }
 

--- a/src/components/common/modal.tsx
+++ b/src/components/common/modal.tsx
@@ -1,0 +1,12 @@
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { closeModal } from "../../store/modalSlice";
+
+export default function Modal() {
+    const dispatch = useAppDispatch();
+    const { isOpen, modalType } = useAppSelector((state) => state.modal);
+    const handleClose = () => dispatch(closeModal());
+
+    if (!isOpen) return null;
+
+    return <div>{modalType === "login" && <></>}</div>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { Provider } from "react-redux";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
+import { store } from "./store/store";
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>
-        <RouterProvider router={router} />
+        <Provider store={store}>
+            <RouterProvider router={router} />
+        </Provider>
     </StrictMode>
 );

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,9 @@
+import type { TypedUseSelectorHook } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "./store";
+
+// 앱 전체에서 'useDispatch' 대신 'useAppDispatch'를 사용
+export const useAppDispatch: () => AppDispatch = useDispatch;
+
+// 앱 전체에서 'useSelector' 대신 'useAppSelector'를 사용
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/modalSlice.ts
+++ b/src/store/modalSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+// modal state Type
+interface ModalState {
+    isOpen: boolean;
+    modalType: string | null; // 어떤 모달을 띄울지 식별 (ex: 'login', 'confirmDelete')
+}
+
+// state의 초기값 설정
+const initialState: ModalState = {
+    isOpen: false,
+    modalType: null,
+};
+
+export const modalSlice = createSlice({
+    name: "modal",
+    initialState,
+    // state를 변경하는 함수(리듀서)들을 reducers 객체 안에 정의
+    reducers: {
+        // openModal 액션
+        // PayloadAction<string>은 action.payload의 타입이 string임을 의미
+        openModal: (state, action: PayloadAction<string>) => {
+            state.isOpen = true;
+            state.modalType = action.payload; // payload로 받은 모달 타입을 state에 저장
+        },
+        // closeModal 액션
+        closeModal: (state) => {
+            state.isOpen = false;
+            state.modalType = null;
+        },
+    },
+});
+
+// 생성된 액션 생성자(action creators)들을 export
+// 컴포넌트에서 이 액션들을 dispatch(실행)할 수 있음
+export const { openModal, closeModal } = modalSlice.actions;
+
+// store.ts에서 reducer를 등록할 수 있도록 default로 export
+export default modalSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,15 @@
+import { configureStore } from "@reduxjs/toolkit";
+import modalReducer from "./modalSlice";
+
+export const store = configureStore({
+    // reducer 객체에 slice들을 추가
+    reducer: {
+        modal: modalReducer,
+        // 다른 slice가 있다면 추가
+    },
+});
+
+// store 자체에서 RootState와 AppDispatch 타입을 추론
+// 이 타입들은 앱 전체에서 사용됨
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## 💡 개요

Redux Toolkit 및 React-Redux를 사용하여 전역 상태 관리를 위한 초기 스토어(Store)와 슬라이스(Slice)를 설정합니다.

---

## 📝 주요 변경 사항

- `package.json`에 `@reduxjs/toolkit`, `react-redux` 의존성을 추가했습니다.
- `src/app/store.js` (또는 `src/store/index.js`) 파일을 생성하여 Redux 스토어를 설정했습니다.
- `src/index.js` (또는 `main.jsx`)에서 `<Provider>` 컴포넌트로 앱 전체를 감싸 스토어를 주입했습니다.
- (선택 사항: 예시 슬라이스를 추가한 경우) 기능 테스트를 위한 예시 슬라이스(예: `counterSlice.js`)를 추가했습니다.

---

## ✅ 기대 효과

- **전역 상태의 중앙 관리:** 여러 컴포넌트에서 공통으로 사용하는 상태를 한곳에서 관리하여 데이터 흐름을 예측 가능하게 만듭니다.
- **'Prop Drilling' 해소:** 불필요하게 props를 계속 넘겨주는 'Prop Drilling' 문제를 해결하여 코드 구조를 단순화합니다.
- **컴포넌트 로직 분리:** 컴포넌트는 UI 렌더링에 집중하고, 상태 관리 로직은 Redux로 분리하여 유지보수성을 높입니다.
- **효율적인 디버깅:** Redux DevTools를 통해 상태 변경 이력을 추적할 수 있어 디버깅이 용이해집니다.