### PR TITLE
feat: mypage에서의 계정 관리(비밀번호 변경/탈퇴) 플로우 구현 및 세션 초기화 리팩터링

### DIFF
--- a/src/components/input/formInput.tsx
+++ b/src/components/input/formInput.tsx
@@ -3,10 +3,16 @@ import { forwardRef, type ForwardedRef, type InputHTMLAttributes } from "react";
 interface FormInputProps {
     error?: string;
     name: string;
+    isPlaceholder: boolean;
 }
 
 const _Input = (
-    { name, error, ...rest }: FormInputProps & InputHTMLAttributes<HTMLElement>,
+    {
+        isPlaceholder,
+        name,
+        error,
+        ...rest
+    }: FormInputProps & InputHTMLAttributes<HTMLElement>,
     ref: ForwardedRef<HTMLInputElement>
 ) => {
     const transfName = (name: string) => {
@@ -16,15 +22,26 @@ const _Input = (
         if (name === "password") {
             return "비밀번호";
         }
+        if (name === "newPassword") {
+            return "새 비밀번호 입력";
+        }
+        if (name === "newPasswordConfirmation") {
+            return "비밀번호 재확인";
+        }
         return name;
     };
     return (
         <div className="flex flex-col">
-            <label className="btn-sub mb-[3px]">{transfName(name)}</label>
+            <label
+                className={`${isPlaceholder ? "hidden" : "flex"} btn-sub mb-[3px]`}
+            >
+                {transfName(name)}
+            </label>
             <input
                 ref={ref}
                 name={name}
                 {...rest}
+                placeholder={isPlaceholder ? transfName(name) : ""}
                 className={`h-[35px] ring-1  rounded-[10px] body-t6 px-[15px] bg-white read-only:bg-background-200 ${error ? "ring-accent" : "ring-background-200"} `}
             />
             <span

--- a/src/components/modal/changePasswordModal.tsx
+++ b/src/components/modal/changePasswordModal.tsx
@@ -5,25 +5,19 @@ import {
 } from "@/schema/changePasswordSchema";
 import { useAppDispatch } from "@/store/hooks";
 import { closeModal } from "@/store/modalSlice";
+import type { ApiResponse } from "@/types/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import axios from "axios";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 import FormButton from "../common/button/formButton";
 import FormInput from "../input/formInput";
 
-interface ChangePasswordResponse {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    result: string;
-}
+type ChangePasswordResponse = ApiResponse<string>;
 
 export default function ChangePasswordModal() {
     const dispatch = useAppDispatch();
     const [isLoading, setIsLoading] = useState(false);
-    const navigate = useNavigate();
     const {
         register,
         handleSubmit,
@@ -41,7 +35,6 @@ export default function ChangePasswordModal() {
             );
             if (response.data.isSuccess) {
                 dispatch(closeModal());
-                await navigate("/");
             }
         } catch (err) {
             if (axios.isAxiosError<ChangePasswordResponse>(err)) {
@@ -82,14 +75,20 @@ export default function ChangePasswordModal() {
                         required
                         {...register("newPassword")}
                         error={errors.newPassword?.message}
+                        type="password"
+                        isPlaceholder
                     />
                     <FormInput
                         required
                         {...register("newPasswordConfirmation")}
                         error={errors.newPasswordConfirmation?.message}
+                        type="password"
+                        isPlaceholder
                     />
                 </article>
-                <span className="body-t5 text-accent">
+                <span
+                    className={`${errors.root?.message ? "flex" : "hidden"} body-t5 text-accent`}
+                >
                     {errors.root?.message}
                 </span>
                 <FormButton

--- a/src/components/modal/deleteAccountModal.tsx
+++ b/src/components/modal/deleteAccountModal.tsx
@@ -1,17 +1,15 @@
 import axiosInstance from "@/api/axiosInstance";
+import { logout } from "@/store/authSlice";
 import { useAppDispatch } from "@/store/hooks";
 import { closeModal } from "@/store/modalSlice";
+import type { ApiResponse } from "@/types/api";
+import { clearAuthToken } from "@/utils/auth";
 import axios from "axios";
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import FormButton from "../common/button/formButton";
 
-interface DeleteAccountResponse {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    result: string;
-}
+type DeleteAccountResponse = ApiResponse<string>;
 
 export default function DeleteAccountModal() {
     const dispatch = useAppDispatch();
@@ -26,14 +24,15 @@ export default function DeleteAccountModal() {
             const response =
                 await axiosInstance.delete<DeleteAccountResponse>("/members");
             if (response.data.isSuccess) {
+                clearAuthToken();
+                dispatch(logout());
                 dispatch(closeModal());
                 await navigate("/");
-                window.location.reload();
             }
         } catch (err) {
             if (axios.isAxiosError(err)) {
                 console.warn(
-                    "비밀번호 변경 실패",
+                    "계정 삭제 실패",
                     err.response?.data || err.message
                 );
                 // 에러 상태 코드별 처리 가능

--- a/src/components/modal/findPasswordModal.tsx
+++ b/src/components/modal/findPasswordModal.tsx
@@ -10,8 +10,8 @@ export default function FindPasswordModal() {
             </div>
             <form className="flex flex-col gap-[15px]">
                 <article className="flex flex-col gap-[5px]">
-                    <FormInput name="학번" />
-                    <FormInput name="샘물 비밀번호" />
+                    <FormInput name="sno" isPlaceholder />
+                    <FormInput name="password" isPlaceholder />
                 </article>
                 <FormButton
                     text="인증"

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -1,0 +1,10 @@
+import { useAppSelector } from "@/store/hooks";
+import { Navigate } from "react-router-dom";
+
+export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
+    const isLogin = useAppSelector((state) => state.authState.isLogin);
+
+    if (!isLogin) return <Navigate to="/login" replace />;
+
+    return children;
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,6 +6,9 @@ import FormInput from "@/components/input/formInput";
 import { loginSchema, type LoginType } from "@/schema/loginSchema";
 import { useAppDispatch } from "@/store/hooks";
 import { openModal } from "@/store/modalSlice";
+import type { ApiResponse } from "@/types/api";
+import type { LoginResult } from "@/types/auth";
+import { fetchAndStoreUser } from "@/utils/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import axios from "axios";
 import Cookies from "js-cookie";
@@ -13,24 +16,12 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
-interface LoginResponse {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    result: {
-        accessToken: string;
-        refreshToken: string;
-    };
-}
+type LoginResponse = ApiResponse<LoginResult>;
 
 export default function Login() {
     const [isLoading, setIsLoading] = useState(false);
 
     const dispatch = useAppDispatch();
-    const handleModalOpen = () => {
-        dispatch(openModal("findPassword"));
-    };
-
     const navigate = useNavigate();
     const {
         register,
@@ -59,8 +50,8 @@ export default function Login() {
                     expires: 7,
                     sameSite: "Lax",
                 });
+                await fetchAndStoreUser(dispatch);
                 await navigate("/");
-                window.location.reload();
             }
         } catch (err) {
             if (axios.isAxiosError<LoginResponse>(err)) {
@@ -90,12 +81,14 @@ export default function Login() {
                         {...register("sno")}
                         required
                         error={errors.sno?.message}
+                        isPlaceholder={false}
                     />
                     <FormInput
                         type="password"
                         {...register("password")}
                         required
                         error={errors.password?.message}
+                        isPlaceholder={false}
                     />
                 </article>
                 <span
@@ -121,7 +114,7 @@ export default function Login() {
                 </article>
             </form>
             <button
-                onClick={handleModalOpen}
+                onClick={() => dispatch(openModal("findPassword"))}
                 className="-m-5 body-t6 underline underline-offset-2 cursor-pointer"
             >
                 비밀번호 찾기

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,24 +1,55 @@
+import axiosInstance from "@/api/axiosInstance";
 import MainLogo from "@/components/common/logo/mainLogo";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { openModal } from "@/store/modalSlice";
+import type { ApiResponse } from "@/types/api";
+import type { Reservation, ReservationsResult } from "@/types/reservation";
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+type ReservationsResponse = ApiResponse<ReservationsResult>;
+
+/*
+[todo]
+1. 예약 변경 버튼 핸들러
+2. 예약 취소 버튼 핸들러
+3. 에러 상태 UI
+ */
 
 export default function MyPage() {
+    const [isLoading, setIsLoading] = useState(false);
+    const [reservations, setReservations] = useState<Reservation[]>([]);
+
     const dispatch = useAppDispatch();
-    const handleModalOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
-        const id = event.currentTarget.id;
-        if (id === "change") dispatch(openModal("changePassword"));
-        if (id === "delete") dispatch(openModal("deleteAccount"));
-    };
 
     const { sno, dept, name } = useAppSelector((state) => state.authState);
 
-    const dummy = [
-        { date: "2025.10.04 (토)", time: "12:00 ~ 14:00" },
-        { date: "2025.10.05 (토)", time: "22:00 ~ 13:00" },
-        { date: "2025.10.06 (토)", time: "11:00 ~ 12:00" },
-        { date: "2025.10.07 (토)", time: "14:00 ~ 15:00" },
-        { date: "2025.10.08 (토)", time: "10:00 ~ 9:00" },
-    ];
+    const getReservations = async () => {
+        setIsLoading(true);
+        try {
+            const response =
+                await axiosInstance.get<ReservationsResponse>(
+                    "/reservations/my"
+                );
+            if (response.data.isSuccess)
+                setReservations(response.data.result.content);
+        } catch (err) {
+            if (axios.isAxiosError<ReservationsResponse>(err)) {
+                console.warn(
+                    "예약 목록 불러오기 실패",
+                    err.response?.data || err.message
+                );
+            } else {
+                console.warn("알 수 없는 에러", err);
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void getReservations();
+    }, []);
 
     return (
         <div className="v-stack w-full">
@@ -27,61 +58,109 @@ export default function MyPage() {
             </div>
             <div className="flex flex-col gap-[30px]">
                 <section className="flex flex-col gap-[15px]">
-                    <p className="body-t1">{}</p>
+                    <p className="body-t1">내 정보</p>
                     <article className="flex flex-col gap-[5px]">
-                        <p className="body-t1">김수뭉</p>
-                        <div className="flex gap-2 body-t3">
+                        <p className="body-t1">{name}</p>
+                        <div className="flex gap-1.5 body-t3">
                             <div className="flex gap-1">
-                                <span>{name}</span>
+                                <span className="text-background-300">
+                                    학번
+                                </span>
                                 <span>{sno}</span>
                             </div>
-                            <span>&#183;</span>
+                            <span className="text-background-300">&#183;</span>
                             <div className="flex gap-1">
-                                <span>학과</span>
+                                <span className="text-background-300">
+                                    학과
+                                </span>
                                 <span>{dept}</span>
                             </div>
                         </div>
                     </article>
                 </section>
-                <section className="flex flex-col gap-[15px]">
-                    <p className="body-t1">예약 기록</p>
-                    <table className="w-full rounded-[5px]">
-                        <thead className="bg-background-200 border">
-                            <tr className="*:py-1.5 *:text-center body-t5">
-                                <td className="">날짜</td>
-                                <td className="border-r border-l">시간대</td>
-                                <td>상태</td>
-                            </tr>
-                        </thead>
-                        <tbody className="border-x border-b">
-                            {dummy.map((data, idx) => (
-                                <tr
-                                    key={idx}
-                                    className=" body-t6 text-center *:py-1.5 border-b"
-                                >
-                                    <td>{data.date}</td>
-                                    <td className="border-r border-l">
-                                        {data.time}
-                                    </td>
-                                    <td className="flex items-center justify-evenly">
-                                        <button className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200 bg-background-[#f5f5f5]">
-                                            변경
-                                        </button>
-                                        <button className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200 bg-background-[#f5f5f5]">
-                                            취소
-                                        </button>
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </section>
+                {!isLoading && (
+                    <section className="flex flex-col gap-[15px]">
+                        <p className="body-t1">예약 기록</p>
+                        <article className="w-full rounded-[5px] border overflow-hidden border-background-300">
+                            <table className="w-full">
+                                <thead className="bg-background-200">
+                                    <tr className="border-b border-background-300 *:py-1.5 text-center body-t5">
+                                        <th scope="col">날짜</th>
+                                        <th
+                                            scope="col"
+                                            className="border-r border-l border-background-300"
+                                        >
+                                            시간대
+                                        </th>
+                                        <th scope="col">상태</th>
+                                    </tr>
+                                </thead>
+                                {reservations.length > 0 ? (
+                                    <tbody className="w-full">
+                                        {reservations.map((data) => (
+                                            <tr
+                                                key={data.reservationId}
+                                                className="body-t6 *:py-1.5 text-center border-b border-background-300 last:border-none"
+                                            >
+                                                <td>{data.date}</td>
+                                                <td className="border-r border-l border-background-300">
+                                                    <span>
+                                                        {data.startTime}
+                                                    </span>
+                                                    <span>{" ~ "}</span>
+                                                    <span>{data.endTime}</span>
+                                                </td>
+                                                <td className="flex items-center justify-evenly">
+                                                    {data.reservationStatus ===
+                                                        "COMPLETED" && (
+                                                        <div className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] bg-background-200">
+                                                            완료
+                                                        </div>
+                                                    )}
+                                                    {data.reservationStatus ===
+                                                        "CANCELLED" && (
+                                                        <div className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] bg-background-200">
+                                                            취소됨
+                                                        </div>
+                                                    )}
+                                                    {data.reservationStatus ===
+                                                        "UPCOMING" && (
+                                                        <>
+                                                            <button className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200">
+                                                                변경
+                                                            </button>
+                                                            <button className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200">
+                                                                취소
+                                                            </button>
+                                                        </>
+                                                    )}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                ) : (
+                                    <tbody className="w-full h-[145px]">
+                                        <tr>
+                                            <td
+                                                colSpan={3}
+                                                className="text-center body-t5 text-background-300"
+                                            >
+                                                예약된 기록이 없습니다
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                )}
+                            </table>
+                        </article>
+                    </section>
+                )}
+
                 <section className="flex justify-between">
                     <span className="body-t1">비밀번호 변경</span>
                     <button
                         id="change"
-                        onClick={handleModalOpen}
-                        className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200 bg-background-[#f5f5f5]"
+                        onClick={() => dispatch(openModal("changePassword"))}
+                        className="cursor-pointer btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200 "
                     >
                         변경하기
                     </button>
@@ -90,8 +169,8 @@ export default function MyPage() {
                     <span className="body-t1">회원 탈퇴</span>
                     <button
                         id="delete"
-                        onClick={handleModalOpen}
-                        className="btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200 bg-background-[#f5f5f5]"
+                        onClick={() => dispatch(openModal("deleteAccount"))}
+                        className="cursor-pointer btn-sub2 px-1.5 py-[1.5px] border rounded-[5px] border-background-200 "
                     >
                         탈퇴하기
                     </button>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -2,25 +2,16 @@ import axiosInstance from "@/api/axiosInstance";
 import FormButton from "@/components/common/button/formButton";
 import SubLogo from "@/components/common/logo/subLogo";
 import FormInput from "@/components/input/formInput";
-import type { LoginType } from "@/schema/loginSchema";
 import { type RegisterType, registerSchema } from "@/schema/registerSchema";
+import type { ApiResponse } from "@/types/api";
+import type { RegisterResult } from "@/types/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import axios from "axios";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
-interface RegisterResponse {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    result: {
-        sno: string;
-        name: string;
-        dept: string;
-        registered: boolean;
-    };
-}
+type RegisterResponse = ApiResponse<RegisterResult>;
 
 export default function Register() {
     const [agreed, setAgreed] = useState(false);
@@ -37,12 +28,7 @@ export default function Register() {
         resolver: zodResolver(registerSchema),
     });
 
-    const handleChange = () => {
-        setAgreed((prev) => !prev);
-        setAgreedError("");
-    };
-
-    const onSubmit = handleSubmit(async (data: LoginType) => {
+    const onSubmit = handleSubmit(async (data: RegisterType) => {
         if (!agreed) {
             setAgreedError("약관에 동의해주세요.");
             return;
@@ -119,11 +105,16 @@ export default function Register() {
                     </ol>
                 </article>
                 <article className="flex gap-1">
-                    <form
-                        onChange={handleChange}
-                        className="ml-[5px] flex gap-[3px] items-center"
-                    >
-                        <input type="checkbox" className="size-2.5" />
+                    <form className="ml-[5px] flex gap-[3px] items-center">
+                        <input
+                            type="checkbox"
+                            checked={agreed}
+                            onChange={(e) => {
+                                setAgreed(e.target.checked);
+                                setAgreedError("");
+                            }}
+                            className="size-2.5"
+                        />
                         <label className="body-t7">
                             다음 약관에 동의합니다.
                         </label>
@@ -158,12 +149,14 @@ export default function Register() {
                                 {...register("sno")}
                                 required
                                 error={errors.sno?.message}
+                                isPlaceholder={false}
                             />
                             <FormInput
                                 type="password"
                                 {...register("password")}
                                 required
                                 error={errors.password?.message}
+                                isPlaceholder={false}
                             />
                         </div>
                         <span

--- a/src/pages/RegisterComplete.tsx
+++ b/src/pages/RegisterComplete.tsx
@@ -6,6 +6,7 @@ import {
     registerCompleteSchema,
     type RegisterCompleteType,
 } from "@/schema/registerCompleteSchema";
+import type { ApiResponse } from "@/types/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import axios from "axios";
 import { useEffect, useState } from "react";
@@ -21,12 +22,7 @@ interface LocationState {
     };
 }
 
-interface RegisterResponse {
-    isSuccess: boolean;
-    code: string;
-    message: string;
-    result: string;
-}
+type RegisterResponse = ApiResponse<string>;
 
 export default function RegisterComplete() {
     const location = useLocation();
@@ -98,12 +94,14 @@ export default function RegisterComplete() {
                         value={userData!.sno}
                         required
                         error={errors.sno?.message}
+                        isPlaceholder={false}
                     />
                     <FormInput
                         type="password"
                         required
                         {...register("password")}
                         error={errors.password?.message}
+                        isPlaceholder={false}
                     />
                 </article>
                 <span

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, Outlet } from "react-router-dom";
 import App from "./App";
+import { ProtectedRoute } from "./components/route/ProtectedRoute";
 import AdminHome from "./pages/AdminHome";
 import AdminReserveManagement from "./pages/AdminReserveManagement";
 import AdminUserManagement from "./pages/AdminUserManagement";
@@ -42,17 +43,29 @@ export const router = createBrowserRouter([
             },
             {
                 path: "reserve",
-                element: <Reserve />,
+                element: (
+                    <ProtectedRoute>
+                        <Reserve />
+                    </ProtectedRoute>
+                ),
             },
             {
                 path: "mypage",
-                element: <MyPage />,
+                element: (
+                    <ProtectedRoute>
+                        <MyPage />
+                    </ProtectedRoute>
+                ),
             },
 
             // 관리자 페이지
             {
                 path: "admin",
-                element: <Outlet />,
+                element: (
+                    <ProtectedRoute>
+                        <Outlet />
+                    </ProtectedRoute>
+                ),
                 children: [
                     {
                         index: true, // path: '/admin'

--- a/src/schema/changePasswordSchema.ts
+++ b/src/schema/changePasswordSchema.ts
@@ -8,6 +8,7 @@ export const changePasswordSchema = z
     })
     .refine((data) => data.newPassword === data.newPasswordConfirmation, {
         message: "비밀번호가 일치하지 않습니다.",
+        path: ["newPasswordConfirmation"],
     });
 
 export type ChangePasswordType = z.infer<typeof changePasswordSchema>;

--- a/src/store/modalSlice.ts
+++ b/src/store/modalSlice.ts
@@ -3,8 +3,13 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 // modal state Type
 interface ModalState {
     isOpen: boolean;
-    modalType: string | null; // 어떤 모달을 띄울지 식별 (ex: 'login', 'confirmDelete')
+    modalType: ModalType | null; // 어떤 모달을 띄울지 식별 (ex: 'login', 'confirmDelete')
 }
+type ModalType =
+    | "findPassword"
+    | "changePassword"
+    | "deleteAccount"
+    | "reserveComplete";
 
 // state의 초기값 설정
 const initialState: ModalState = {
@@ -18,8 +23,8 @@ export const modalSlice = createSlice({
     // state를 변경하는 함수(리듀서)들을 reducers 객체 안에 정의
     reducers: {
         // openModal 액션
-        // PayloadAction<string>은 action.payload의 타입이 string임을 의미
-        openModal: (state, action: PayloadAction<string>) => {
+        // PayloadAction<modalType>은 action.payload의 타입이 modalType임을 의미
+        openModal: (state, action: PayloadAction<ModalType>) => {
             state.isOpen = true;
             state.modalType = action.payload; // payload로 받은 모달 타입을 state에 저장
         },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,6 @@
+export interface ApiResponse<T> {
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: T;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,19 @@
+export interface MemberResult {
+    id: number;
+    sno: string;
+    name: string;
+    dept: string;
+    status: string;
+}
+
+export interface LoginResult {
+    accessToken: string;
+    refreshToken: string;
+}
+
+export interface RegisterResult {
+    sno: string;
+    name: string;
+    dept: string;
+    registered: boolean;
+}

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -1,0 +1,16 @@
+export interface Reservation {
+    reservationId: number;
+    date: string;
+    startTime: string;
+    endTime: string;
+    reservationStatus: ReservationStatus;
+}
+export interface ReservationsResult {
+    content: Reservation[];
+    currentPage: number;
+    totalPages: number;
+    totalElements: number;
+    first: boolean;
+    last: boolean;
+}
+export type ReservationStatus = "UPCOMING" | "COMPLETED" | "CANCELLED";

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,43 @@
+import axiosInstance from "@/api/axiosInstance";
+import { login } from "@/store/authSlice";
+import type { AppDispatch } from "@/store/store";
+import type { ApiResponse } from "@/types/api";
+import type { MemberResult } from "@/types/auth";
+import axios from "axios";
+import Cookies from "js-cookie";
+
+export const clearAuthToken = () => {
+    Cookies.remove("accessToken");
+    Cookies.remove("refreshToken");
+};
+
+type MemberResponse = ApiResponse<MemberResult>;
+
+export const fetchAndStoreUser = async (dispatch: AppDispatch) => {
+    const accessToken = Cookies.get("accessToken");
+    if (!accessToken) return null;
+
+    try {
+        const user = await axiosInstance.get<MemberResponse>("/members/my");
+        if (user.data.isSuccess) {
+            dispatch(
+                login({
+                    sno: user.data.result.sno,
+                    name: user.data.result.name,
+                    dept: user.data.result.dept,
+                })
+            );
+        }
+        return user;
+    } catch (err) {
+        if (axios.isAxiosError<MemberResponse>(err)) {
+            console.warn(
+                "유저 데이터 불러오기 실패",
+                err.response?.data || err.message
+            );
+        } else {
+            console.warn("알 수 없는 에러", err);
+        }
+        return null;
+    }
+};


### PR DESCRIPTION
## 💡 개요

마이페이지 관련 계정 관리 기능(비밀번호 변경, 회원 탈퇴)과 인증 세션 초기화를 구현/리팩터링했습니다. 앱 초기 구동 시 세션을 일원화하여 로그인 상태를 안정적으로 복원하고, 폼 에러 표시 방식을 공통 패턴으로 정리했습니다.

---

## 📝 주요 변경 사항

- App
  - 앱 최초 마운트 시 쿠키(accessToken) 확인 후 /members/my 호출로 사용자 정보 로드 및 [login](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 디스패치
  - 세션 불일치/에러 시 토큰 제거 처리 정비
- Login
  - 로그인 성공 시 단순 리다이렉트 → 홈 이동 후 새로고침으로 세션 부트스트랩 책임을 App로 이관
  - 루트 에러 메시지 조건부 렌더링(class 토글)로 통일
- Register / RegisterComplete
  - 폼 루트 에러 메시지 표시 방식을 조건부 렌더링으로 통일
- ChangePasswordModal
  - 스키마 필드명 명확화: [password/confirmPassword](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [newPassword/newPasswordConfirmation](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
  - 변경 성공 시 모달 닫기([closeModal](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) 및 홈 이동
- DeleteAccountModal
  - 탈퇴 API 연동(/members DELETE), 성공 시 모달 닫기 + 홈 이동 후 새로고침
  - 공통 버튼 컴포넌트([FormButton](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) 사용으로 로딩/비활성 처리 일관화
- Schema
  - [changePasswordSchema](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 필드명 및 일치 검증 로직 업데이트

---

## 🔗 관련 이슈

Closes #11 

---

## 📌 리뷰 요청 사항

- App에서 세션 부트스트랩(토큰→/members/my→redux [login](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) 흐름에 대한 구조적 **타당성**
- 로그인 성공 후 새로고침으로 책임 이관한 부분에 대한 사용자 경험/성능 고려
- changePassword 필드명 변경으로 인한 다른 사용처 영향 여부
- 에러 메시지 표시(class 토글) 패턴의 가독성/일관성
